### PR TITLE
recipe/build.sh: skip static libraries as intended on non-Windows

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -55,7 +55,7 @@ make check
 rm -rf $uprefix/share/doc/libXdmcp
 
 # Non-Windows: prefer dynamic libraries to static, and dump libtool helper files
-if [ -z "CYGWIN_PREFIX" ] ; then
+if [ -z "$CYGWIN_PREFIX" ] ; then
     for lib_ident in Xdmcp; do
         rm -f $uprefix/lib/lib${lib_ident}.la $uprefix/lib/lib${lib_ident}.a
     done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - windows.patch  # [win]
 
 build:
-  number: 5
+  number: 6
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
